### PR TITLE
User can select who goes first

### DIFF
--- a/lib/TTT/game.ex
+++ b/lib/TTT/game.ex
@@ -27,15 +27,15 @@ defmodule Game do
 
   def play(state, io, mode) do
     Messages.display_board(io, state)
-    player = state.player
-    opponent = state.opponent
+    player1 = state.player
+    player2 = state.opponent
 
     case state.current_player do
-      ^player ->
+      ^player1 ->
         human_move(state, io, mode)
         |> check_status(io, mode)
 
-      ^opponent ->
+      ^player2 ->
         opponent(state, io, mode)
         |> check_status(io, mode)
     end
@@ -84,15 +84,15 @@ defmodule Game do
     end
   end
 
-  defp opponent(state, io, mode) when mode == @mode1 do
-    human_move(state, io, mode)
+  defp opponent(state, io, @mode1) do
+    human_move(state, io, @mode1)
   end
 
-  defp opponent(state, _io, mode) when mode == @mode2 do
+  defp opponent(state, _io, @mode2) do
     easy_computer_move(state)
   end
 
-  defp opponent(state, _io, mode) when mode == @mode3 do
+  defp opponent(state, _io, @mode3) do
     hard_computer_move(state)
   end
 end

--- a/lib/TTT/game.ex
+++ b/lib/TTT/game.ex
@@ -27,10 +27,10 @@ defmodule Game do
 
   def play(state, io, mode) do
     Messages.display_board(io, state)
-    player1 = state.player
-    player2 = state.opponent
+    player1 = State.get_player(state)
+    player2 = State.get_opponent(state)
 
-    case state.current_player do
+    case State.get_current_player(state) do
       ^player1 ->
         human_move(state, io, mode)
         |> check_status(io, mode)
@@ -57,7 +57,7 @@ defmodule Game do
   end
 
   def human_move(state, io, _mode) do
-    io.retrieve(state.current_player <> Messages.get_message(:choose))
+    io.retrieve(State.get_current_player(state) <> Messages.get_message(:choose))
     |> Validation.sanitized_move()
     |> Player.check_move(state, io)
   end

--- a/lib/TTT/messages.ex
+++ b/lib/TTT/messages.ex
@@ -14,7 +14,9 @@ defmodule Messages do
       opponent_move: "Opponent's turn:",
       winner: " is the winner of this game!",
       same_token: "Please enter a unique symbol",
-      token_length_error: "Please choose a token that is 1 character long"
+      token_length_error: "Please choose a token that is 1 character long",
+      choose_first_player: "Please choose which player should go first ",
+      first_player_error: "Please enter either the player or the opponent's token."
     }
 
     messages[term]

--- a/lib/TTT/minimax.ex
+++ b/lib/TTT/minimax.ex
@@ -22,10 +22,10 @@ defmodule Minimax do
 
   def score_move(state, winner) do
     cond do
-      state.player == winner ->
+      State.get_player(state) == winner ->
         %{score: -20}
 
-      state.opponent == winner ->
+      State.get_opponent(state) == winner ->
         %{score: 20}
 
       nil == winner ->
@@ -34,9 +34,9 @@ defmodule Minimax do
   end
 
   def optimal_move(moves, state) do
-    min = state.player
-    max = state.opponent
-    current = state.current_player
+    min = State.get_player(state)
+    max = State.get_opponent(state)
+    current = State.get_current_player(state)
 
     case current do
       ^max ->

--- a/lib/TTT/state.ex
+++ b/lib/TTT/state.ex
@@ -35,6 +35,10 @@ defmodule State do
     state.opponent
   end
 
+  def get_current_player(state) do
+    state.current_player
+  end
+
   def invert(state) do
     State.get_board(state)
     |> Enum.reduce(%{}, fn {k, vs}, acc ->

--- a/lib/TTT/validation.ex
+++ b/lib/TTT/validation.ex
@@ -39,6 +39,23 @@ defmodule Validation do
     end
   end
 
+  def choose_first_player(io, player_token, opponent_token) do
+    io.retrieve(
+      Messages.get_message(:choose_first_player) <> "(#{player_token} or #{opponent_token}): "
+    )
+    |> clean()
+    |> validate_first_player(io, player_token, opponent_token)
+  end
+
+  def validate_first_player(first_player, io, player_token, opponent_token) do
+    if first_player == player_token or first_player == opponent_token do
+      first_player
+    else
+      io.display(Messages.get_message(:first_player_error))
+      choose_first_player(io, player_token, opponent_token)
+    end
+  end
+
   def choose_token(io) do
     io.retrieve(Messages.get_message(:choose_token))
     |> clean()

--- a/lib/TTT/validation.ex
+++ b/lib/TTT/validation.ex
@@ -44,15 +44,27 @@ defmodule Validation do
       Messages.get_message(:choose_first_player) <> "(#{player_token} or #{opponent_token}): "
     )
     |> clean()
-    |> validate_first_player(io, player_token, opponent_token)
+    |> validate_first_player(player_token, opponent_token)
+    |> case do
+      {:ok, first_player} ->
+        first_player
+
+      {:error} ->
+        io.display(Messages.get_message(:first_player_error))
+        choose_first_player(io, player_token, opponent_token)
+    end
   end
 
-  def validate_first_player(first_player, io, player_token, opponent_token) do
-    if first_player == player_token or first_player == opponent_token do
-      first_player
-    else
-      io.display(Messages.get_message(:first_player_error))
-      choose_first_player(io, player_token, opponent_token)
+  def validate_first_player(first_player, player_token, opponent_token) do
+    case first_player do
+      ^player_token ->
+        {:ok, first_player}
+
+      ^opponent_token ->
+        {:ok, first_player}
+
+      _ ->
+        {:error}
     end
   end
 

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -19,13 +19,14 @@ defmodule GameTest do
           },
           player: "X",
           opponent: "O",
-          current_player: "X"
+          current_player: "X",
+          mode: :empty
         }
       }
     end
 
     test "initializes game with player token \"a\" opponent token \"b\" and current player \"a\"" do
-      assert Game.set_options("a", "b", :human_v_human) == %State{
+      assert Game.set_options("a", "b", "b", :human_v_human) == %State{
                board: %{
                  {0, 0} => 1,
                  {0, 1} => 2,
@@ -37,7 +38,7 @@ defmodule GameTest do
                  {2, 1} => 8,
                  {2, 2} => 9
                },
-               current_player: "a",
+               current_player: "b",
                opponent: "b",
                player: "a",
                mode: :human_v_human

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -27,6 +27,7 @@ defmodule TicTacToeTest do
         "1\n",
         "a\n",
         "b\n",
+        "b\n",
         "1\n",
         "2\n",
         "3\n",


### PR DESCRIPTION
User is now prompted to select which player goes first. They must enter
the exact player/opponent token to proceed, otherwise they're shown an
error message and are prompted again to choose which player they would
like to go first. Their choice is then set in the current_player field
in the State struct.

The functionality is implemented in Game.play, where the turn is
determined by who the current player is as determined by querying
state.current_player.